### PR TITLE
Add `{$ROOT_URL}` when loading open-sans.css in header

### DIFF
--- a/template/header.tpl
+++ b/template/header.tpl
@@ -3,7 +3,7 @@
 <head>
 <title>{if $PAGE_TITLE=='Home'|@translate}{$GALLERY_TITLE}{else}{$PAGE_TITLE}{/if}</title>
 <link rel="shortcut icon" type="image/x-icon" href="{$ROOT_URL}{$themeconf.icon_dir}/favicon.ico">
-<link rel="stylesheet" type="text/css" href="themes/{$themeconf.id}/css/open-sans/open-sans.css"> {* cannot be loaded by combine_css because it contains relative urls *}
+<link rel="stylesheet" type="text/css" href="{$ROOT_URL}themes/{$themeconf.id}/css/open-sans/open-sans.css"> {* cannot be loaded by combine_css because it contains relative urls *}
 {strip}{get_combined_css}
 {combine_css path="themes/`$themeconf.id`/css/base.css.tpl" version=$MODUS_CSS_VERSION template=true order=-10}
 {combine_css path="themes/`$themeconf.id`/css/iconfontello.css.tpl" version=$MODUS_CSS_VERSION template=true order=-10}


### PR DESCRIPTION
If we don't add it, this CSS file won't be found when

```php
$conf['question_mark_in_urls'] = false;
```

as e.g. https://example.com/index.php/category/1 would try to get https://example.com/index.php/category/themes/modus/css/open-sans/open-sans.css.