### PR TITLE
Update blueberry.css

### DIFF
--- a/skins/blueberry.css
+++ b/skins/blueberry.css
@@ -22,7 +22,7 @@ body{
 #copyright A{color:#93c2d6;}
 
 .infos{
-  background:#096a09 url(/themes/default/icon/infos.png) no-repeat center right;
+  background:#096a09 url(../../default/icon/infos.png) no-repeat center right;
   color:black;
 }
 


### PR DESCRIPTION
If Piwigo is installed in a sub-directory, the path of the icon is wrong.
Guess the same with all other skins ..

btw: this "info" icon is ugly and when used, it should be more left (or left side of the text)!
![grafik](https://github.com/Piwigo/piwigo-modus/assets/1905204/8d9d26be-a023-4311-ae49-0ada0435433e)
