### PR TITLE
Use gallery title in page title

### DIFF
--- a/template/header.tpl
+++ b/template/header.tpl
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang={$lang_info.code} dir={$lang_info.direction}>
 <head>
-<title>{if $PAGE_TITLE=='Home'|@translate}{$GALLERY_TITLE}{else}{$PAGE_TITLE}{/if}</title>
+<title>{if $PAGE_TITLE!=l10n('Home') && $PAGE_TITLE!=$GALLERY_TITLE}{$PAGE_TITLE} | {/if}{$GALLERY_TITLE}</title>
 <link rel="shortcut icon" type="image/x-icon" href="{$ROOT_URL}{$themeconf.icon_dir}/favicon.ico">
 <link rel="stylesheet" type="text/css" href="{$ROOT_URL}themes/{$themeconf.id}/css/open-sans/open-sans.css"> {* cannot be loaded by combine_css because it contains relative urls *}
 {strip}{get_combined_css}


### PR DESCRIPTION
This changes the `<title>` content to be the same as the default template so it always includes the galllery title.

---

Globally I think it would be useful to audit the whole file. It could be removed (use the default one) with few (if any) adjustements in the stylesheets.